### PR TITLE
fix: add customIntrumentations configuration option

### DIFF
--- a/src/otel.ts
+++ b/src/otel.ts
@@ -133,7 +133,7 @@ export class OtelManager {
    * Process user instrumentation configuration
    */
   #processUserInstrumentations(userConfig: OtelConfig['instrumentations']) {
-    const customInstances: Instrumentation[] = []
+    const customInstances: Instrumentation[] = this.#config.customInstrumentations ?? []
     const disabledSet = new Set<string>()
     const configOverrides: Partial<InstrumentationConfigMap> = {}
     let httpConfig: HttpInstrumentationConfig | undefined

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export type { SpanOptions } from './decorators.js'
 export { hiddenFields, type HiddenField, type OtelLoggingPresetOptions } from './logging.js'
 
 import type { InstrumentationsConfig } from './instrumentations.js'
+import { Instrumentation } from '@opentelemetry/instrumentation'
 
 /**
  * Configuration for @adonisjs/otel
@@ -103,6 +104,18 @@ export interface OtelConfig extends Partial<
    * ```
    */
   instrumentations?: InstrumentationsConfig
+
+  /**
+   * Custom instrumentations instances.
+   *
+   * @exampl
+   * ```ts
+   * customInstrumentations: [
+   *   new MyCustomInstrumentation()
+   * ]
+   * ```
+   */
+  customInstrumentations?: Instrumentation[]
 
   /**
    * Configure automatic user context extraction in the middleware.


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull-request add the configuration option `customInstrumentations` allowing the user to pass custom instrumentation instances.

```ts
import { defineConfig } from '@adonisjs/otel'
import env from '#start/env'
import { ActionsInstrumentation } from '@foadonis/actions/instrumentation'

export default defineConfig({
  serviceName: env.get('APP_NAME'),
  serviceVersion: env.get('APP_VERSION'),
  environment: env.get('APP_ENV'),

  instrumentations: {
    '@opentelemetry/instrumentation-pg': { enabled: false },
  },

  customInstrumentations: [new ActionsInstrumentation()],
})
```

It was difficult to reuse the current `instrumentations` option without changing a lot of things as it has been made for overriding config of node auto instrumentations.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
