### PR TITLE
Fix bug in passing userContext to OTEL middleware

### DIFF
--- a/providers/otel_provider.ts
+++ b/providers/otel_provider.ts
@@ -41,9 +41,7 @@ export default class OtelProvider {
    */
   #registerMiddleware() {
     this.app.container.singleton(OtelMiddleware, async () => {
-      const otelConfigProvider = this.app.config.get<OtelConfig>('otel', {})
-      const config = await configProvider.resolve<OtelConfig>(this.app, otelConfigProvider)
-
+      const config = this.app.config.get<OtelConfig>('otel', {})
       return new OtelMiddleware({ userContext: config?.userContext })
     })
   }


### PR DESCRIPTION
`userContext` was always undefined. this passes the correct config value for userContext

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
